### PR TITLE
Update Makefile for using with Eclipse CDT; Fix -O0 undefined reference ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.o
 main
+.cproject
+.project
+.settings

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-CFLAGS  = -std=c11 -Wall -O3 -mcx16
+CFLAGS  = -std=c11 -Wall -O0 -mcx16
 LDFLAGS = -pthread
+
+all : main
 
 main : main.o lstack.o sha1.o
 

--- a/main.c
+++ b/main.c
@@ -11,6 +11,8 @@ struct job {
     size_t min_results, nzeros;
 };
 
+extern size_t lstack_size(lstack_t *lstack);
+
 const char EMPTY[SHA1_DIGEST_SIZE] = {0};
 
 void print_hash(unsigned char hash[SHA1_DIGEST_SIZE])


### PR DESCRIPTION
I wanted to read full assembly, but linking with -O0 failed.

```
cc -std=c11 -Wall -O0 -mcx16   -c -o main.o main.c
cc -pthread  main.o lstack.o sha1.o   -o main
main.o: In function `worker':
main.c:(.text+0x1c5): undefined reference to `lstack_size'
main.o: In function `main':
main.c:(.text+0x367): undefined reference to `lstack_size'
main.c:(.text+0x3b7): undefined reference to `lstack_size'
collect2: error: ld returned 1 exit status
<builtin>: recipe for target 'main' failed
make: *** [main] Error 1
```

Found this: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49653#c11 and added an extern declaration.

I couldn't come up with a better fix.
