### PR TITLE
replace gcc with clang to avoid errors from gcc 7.4/8.1 compiler and ld linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .POSIX:
-CC      = cc
+CC      = clang
 CFLAGS  = -std=c11 -Wall -Wextra -O3 -mcx16
 LDFLAGS = -pthread
 


### PR DESCRIPTION
1. `make CC=clang` success
```
liuqun@vmware:~/aaa/dpdk/lstack$ make clean
rm -f main main.o lstack.o sha1.o
liuqun@vmware:~/aaa/dpdk/lstack$ make CC=clang
clang -std=c11 -Wall -Wextra -O3 -mcx16   -c -o main.o main.c
clang -std=c11 -Wall -Wextra -O3 -mcx16   -c -o lstack.o lstack.c
clang -std=c11 -Wall -Wextra -O3 -mcx16   -c -o sha1.o sha1.c
clang -std=c11 -Wall -Wextra -O3 -mcx16 -pthread -o main main.o lstack.o sha1.o 
```

2. GCC-7.4 and GCC-8 with /usr/bin/ld error message:
```
liuqun@vmware:~/aaa/dpdk/lstack$ make clean
rm -f main main.o lstack.o sha1.o
liuqun@vmware:~/aaa/dpdk/lstack$ make CC=gcc-7
gcc-7 -std=c11 -Wall -Wextra -O3 -mcx16   -c -o main.o main.c
gcc-7 -std=c11 -Wall -Wextra -O3 -mcx16   -c -o lstack.o lstack.c
gcc-7 -std=c11 -Wall -Wextra -O3 -mcx16   -c -o sha1.o sha1.c
gcc-7 -std=c11 -Wall -Wextra -O3 -mcx16 -pthread -o main main.o lstack.o sha1.o 
/usr/bin/ld: lstack.o: in function `lstack_init':
lstack.c:(.text+0x1b): undefined reference to `__atomic_store_16'
/usr/bin/ld: lstack.c:(.text+0x75): undefined reference to `__atomic_store_16'
/usr/bin/ld: lstack.o: in function `lstack_push':
lstack.c:(.text+0xc0): undefined reference to `__atomic_load_16'
/usr/bin/ld: lstack.c:(.text+0xf5): undefined reference to `__atomic_compare_exchange_16'
/usr/bin/ld: lstack.c:(.text+0x121): undefined reference to `__atomic_load_16'
/usr/bin/ld: lstack.c:(.text+0x14f): undefined reference to `__atomic_compare_exchange_16'
/usr/bin/ld: lstack.o: in function `lstack_pop':
lstack.c:(.text+0x1dd): undefined reference to `__atomic_load_16'
/usr/bin/ld: lstack.c:(.text+0x212): undefined reference to `__atomic_compare_exchange_16'
/usr/bin/ld: lstack.c:(.text+0x23b): undefined reference to `__atomic_load_16'
/usr/bin/ld: lstack.c:(.text+0x269): undefined reference to `__atomic_compare_exchange_16'
collect2: error: ld returned 1 exit status
make: *** [Makefile:9：main] Error 1
```

```
liuqun@vmware:~/aaa/dpdk/lstack$ make clean
rm -f main main.o lstack.o sha1.o
liuqun@vmware:~/aaa/dpdk/lstack$ make CC=gcc-8
gcc-8 -std=c11 -Wall -Wextra -O3 -mcx16   -c -o main.o main.c
gcc-8 -std=c11 -Wall -Wextra -O3 -mcx16   -c -o lstack.o lstack.c
gcc-8 -std=c11 -Wall -Wextra -O3 -mcx16   -c -o sha1.o sha1.c
gcc-8 -std=c11 -Wall -Wextra -O3 -mcx16 -pthread -o main main.o lstack.o sha1.o 
/usr/bin/ld: lstack.o: in function `lstack_init':
lstack.c:(.text+0x23): undefined reference to `__atomic_store_16'
/usr/bin/ld: lstack.c:(.text+0xf4): undefined reference to `__atomic_store_16'
/usr/bin/ld: lstack.o: in function `lstack_push':
lstack.c:(.text+0x14d): undefined reference to `__atomic_load_16'
/usr/bin/ld: lstack.c:(.text+0x185): undefined reference to `__atomic_compare_exchange_16'
/usr/bin/ld: lstack.c:(.text+0x1a8): undefined reference to `__atomic_load_16'
/usr/bin/ld: lstack.c:(.text+0x1d6): undefined reference to `__atomic_compare_exchange_16'
/usr/bin/ld: lstack.o: in function `lstack_pop':
lstack.c:(.text+0x25a): undefined reference to `__atomic_load_16'
/usr/bin/ld: lstack.c:(.text+0x292): undefined reference to `__atomic_compare_exchange_16'
/usr/bin/ld: lstack.c:(.text+0x2bb): undefined reference to `__atomic_load_16'
/usr/bin/ld: lstack.c:(.text+0x2e9): undefined reference to `__atomic_compare_exchange_16'
collect2: error: ld returned 1 exit status
make: *** [Makefile:9：main] Error 1
liuqun@vmware:~/aaa/dpdk/lstack$ 

```


3. GCC-6 worked for me
```
liuqun@vmware:~/aaa/dpdk/lstack$ make clean
rm -f main main.o lstack.o sha1.o
liuqun@vmware:~/aaa/dpdk/lstack$ make CC=gcc-6
gcc-6 -std=c11 -Wall -Wextra -O3 -mcx16   -c -o main.o main.c
gcc-6 -std=c11 -Wall -Wextra -O3 -mcx16   -c -o lstack.o lstack.c
gcc-6 -std=c11 -Wall -Wextra -O3 -mcx16   -c -o sha1.o sha1.c
gcc-6 -std=c11 -Wall -Wextra -O3 -mcx16 -pthread -o main main.o lstack.o sha1.o 
```